### PR TITLE
list after-hours events on schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,12 @@
                         <h1 class="h-section" id="schedule">Schedule</h1>
                         <ul class="nav nav--block schedule-day-list">
                             <li>
+                                <a href="#" class="schedule-day-item" data-target-panel="schedule-pre-conf">
+                                  <h2 class="h-header schedule-day-list__title">Pre-Conference</h2>
+                                  <span class="schedule-day-list__date">Wednesday Oct. 11th</span>
+                                </a>
+                            </li>
+                            <li>
                                 <a href="#" class="schedule-day-item schedule-day-item--active" data-target-panel="schedule-javascript-day">
                                     <h2 class="h-header schedule-day-list__title">JavaScript Day</h2>
                                     <span class="schedule-day-list__date">Thursday Oct. 12th</span>
@@ -159,6 +165,12 @@
                                 </a>
                             </li>
                         </ul>
+                        <div class="schedule" id="schedule-pre-conf">
+                            <div class="schedule-time">6:30pm - 9:00pm</div>
+                            <div class="schedule-announcement">
+                                <h3 class="h-header h-trimmed">EmpireConf Icebreakers at Microsoft Terrace</h3>
+                            </div>
+                        </div>
                         <div class="schedule schedule--active" id="schedule-javascript-day">
                             <div class="schedule-time">8:00am - 9:15am</div>
                             <div class="schedule-announcement">
@@ -291,6 +303,10 @@
                             <div class="schedule-announcement">
                                 <h3 class="h-header h-trimmed">Workshops Continue</h3>
                             </div>
+                            <div class="schedule-time">6:30pm - 9:30pm</div>
+                            <div class="schedule-announcement">
+                                <h3 class="h-header h-trimmed">Computer Science Theatre 2000</h3>
+                            </div>
                         </div>
                         <div class="schedule" id="schedule-node-day">
                             <div class="schedule-time">8:00am - 9:15am</div>
@@ -420,6 +436,10 @@
                             <div class="schedule-time">4:00pm - 5:30pm</div>
                             <div class="schedule-announcement">
                                 <h3 class="h-header h-trimmed">Workshops Continue</h3>
+                            </div>
+                            <div class="schedule-time">6:15pm - 10pm</div>
+                            <div class="schedule-announcement">
+                                <h3 class="h-header h-trimmed">Empire Jazz Lounge Cruise</h3>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Closes #18.

We've gotten several questions about the schedule outside of the conference hours - this gets the times and titles on the site.

<img width="1181" alt="screen shot 2017-09-22 at 9 25 23 am" src="https://user-images.githubusercontent.com/86842/30746490-e7e8ce6a-9f77-11e7-9481-42255610d363.png">

@hackygolucky We're ok posting the titles, yeah? Or should I just list "opening night party", etc?

Note this does not include the descriptions, which are listed in https://github.com/EmpireJS/empireconf-2017-staff/issues/28. @jakefolio The schedule entries with descriptions all seemed to be formatted for talks specifically - wasn't sure of the best way to put them in for parties. Assuming the answer to the question for @hackygolucky above is "yes", would you mind taking a pass to add them, as a follow-up?

Thanks!

## Follow-up TODOs

* [ ] Reply to https://twitter.com/simonstl/status/910485642546700293
* [ ] Tweet that the events have been added to the schedule